### PR TITLE
Option to check files in bulk by specifying a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This script checks for common mistakes in LaTeX source files of scientific paper
 
 ## Usage
 
-    python3 paperlint.py <file.tex> [-i/x <include/exclude switch>] [--error]
-    
+    python3 paperlint.py <file.tex/path> [-i/x <include/exclude switch>] [--error]
+
+Provide either a single .tex file to check or a path to recursively check all .tex files in that directory!
 By default, all rules are used for checking the document.
 The switches can be configured with the `-x` and `-i` parameters to exclude and include entire categories of rules or single rules. 
 The include/exclude switches are evaluated in the order they are specified. 

--- a/paperlint.py
+++ b/paperlint.py
@@ -5,7 +5,7 @@ import os
 
 
 def usage():
-    print("%s <file/path> [-x <excluded-switch1>] [-i <included-switch1>] [-i/x <switch n, evaluated in order of specification>] [--error]" % sys.argv[0])
+    print("%s <file.tex/path> [-x <excluded-switch1>] [-i <included-switch1>] [-i/x <switch n, evaluated in order of specification>] [--error]" % sys.argv[0])
     sys.exit(1)
 
 if len(sys.argv) < 2:


### PR DESCRIPTION
Can now do something like
"python3 paperlint.py ./content/introduction" to check many files in the specified directory in bulk.
Under the hood we walk the filesystem, find all files ending in .tex and add them to a list to check.

The functionality of the code has not changed, i.e., passing single files still works the same!